### PR TITLE
Send NotifySettingsChange message to players

### DIFF
--- a/Code/client/Services/Generic/TransportService.cpp
+++ b/Code/client/Services/Generic/TransportService.cpp
@@ -17,6 +17,7 @@
 
 #include <Messages/AuthenticationRequest.h>
 #include <Messages/ServerMessageFactory.h>
+#include <Messages/NotifySettingsChange.h>
 #include <Packet.hpp>
 
 #include <ScriptExtender.h>
@@ -33,6 +34,7 @@ TransportService::TransportService(World& aWorld, entt::dispatcher& aDispatcher)
     : m_world(aWorld), m_dispatcher(aDispatcher)
 {
     m_updateConnection = m_dispatcher.sink<UpdateEvent>().connect<&TransportService::HandleUpdate>(this);
+    m_settingsChangeConnection = m_dispatcher.sink<NotifySettingsChange>().connect<&TransportService::HandleNotifySettingsChange>(this);
 
     m_connected = false;
 
@@ -246,4 +248,10 @@ void TransportService::HandleAuthenticationResponse(const AuthenticationResponse
     }
 
     m_dispatcher.trigger(errorEvent);
+}
+
+void TransportService::HandleNotifySettingsChange(const NotifySettingsChange& acMessage) noexcept
+{
+    m_world.SetServerSettings(acMessage.Settings);
+    m_dispatcher.trigger(acMessage.Settings);
 }

--- a/Code/client/Services/TransportService.h
+++ b/Code/client/Services/TransportService.h
@@ -7,6 +7,7 @@ struct ImguiService;
 struct UpdateEvent;
 struct ClientMessage;
 struct AuthenticationResponse;
+struct NotifySettingsChange;
 
 struct World;
 
@@ -42,6 +43,7 @@ protected:
 
     // Packet handlers
     void HandleAuthenticationResponse(const AuthenticationResponse& acMessage) noexcept;
+    void HandleNotifySettingsChange(const NotifySettingsChange& acMessage) noexcept;
 
 private:
 
@@ -52,5 +54,6 @@ private:
 
     entt::scoped_connection m_updateConnection;
     entt::scoped_connection m_sendServerMessageConnection;
+    entt::scoped_connection m_settingsChangeConnection;
     std::function<void(UniquePtr<ServerMessage>&)> m_messageHandlers[kServerOpcodeMax];
 };

--- a/Code/encoding/Messages/NotifySettingsChange.cpp
+++ b/Code/encoding/Messages/NotifySettingsChange.cpp
@@ -1,0 +1,14 @@
+#include <Messages/NotifySettingsChange.h>
+#include <TiltedCore/Serialization.hpp>
+
+void NotifySettingsChange::SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept
+{
+    Settings.Serialize(aWriter);
+}
+
+void NotifySettingsChange::DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept
+{
+    ServerMessage::DeserializeRaw(aReader);
+
+    Settings.Deserialize(aReader);
+}

--- a/Code/encoding/Messages/NotifySettingsChange.h
+++ b/Code/encoding/Messages/NotifySettingsChange.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Message.h"
+#include <Structs/ServerSettings.h>
+
+struct NotifySettingsChange final : ServerMessage
+{
+    static constexpr ServerOpcode Opcode = kNotifySettingsChange;
+
+    NotifySettingsChange() : 
+        ServerMessage(Opcode)
+    {
+    }
+
+    virtual ~NotifySettingsChange() = default;
+
+    void SerializeRaw(TiltedPhoques::Buffer::Writer& aWriter) const noexcept override;
+    void DeserializeRaw(TiltedPhoques::Buffer::Reader& aReader) noexcept override;
+
+    bool operator==(const NotifySettingsChange& acRhs) const noexcept
+    {
+        return GetOpcode() == acRhs.GetOpcode() &&
+               Settings == acRhs.Settings;
+    }
+
+    ServerSettings Settings{};
+};

--- a/Code/encoding/Messages/ServerMessageFactory.h
+++ b/Code/encoding/Messages/ServerMessageFactory.h
@@ -54,6 +54,7 @@
 #include <Messages/NotifyPlayerCellChanged.h>
 #include <Messages/NotifyTeleport.h>
 #include <Messages/NotifyPlayerHealthUpdate.h>
+#include <Messages/NotifySettingsChange.h>
 
 using TiltedPhoques::UniquePtr;
 
@@ -76,7 +77,7 @@ struct ServerMessageFactory
                                  TeleportCommandResponse, NotifyPlayerRespawn, NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue,
                                  NotifyActorTeleport, NotifyRelinquishControl, NotifyPlayerLeft, NotifyPlayerJoined, 
                                  NotifyDialogue, NotifySubtitle, NotifyPlayerDialogue, NotifyPlayerLevel, NotifyPlayerCellChanged,
-                                 NotifyTeleport, NotifyPlayerHealthUpdate>;
+                                 NotifyTeleport, NotifyPlayerHealthUpdate, NotifySettingsChange>;
 
         return s_visitor(std::forward<T>(func));
     }

--- a/Code/encoding/Opcodes.h
+++ b/Code/encoding/Opcodes.h
@@ -104,5 +104,6 @@ enum ServerOpcode : unsigned char
     kNotifyPlayerCellChanged,
     kNotifyTeleport,
     kNotifyPlayerHealthUpdate,
+    kNotifySettingsChange,
     kServerOpcodeMax
 };

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -18,6 +18,7 @@
 #include <Messages/ClientMessageFactory.h>
 #include <Messages/NotifyPlayerLeft.h>
 #include <Messages/NotifyPlayerJoined.h>
+#include <Messages/NotifySettingsChange.h>
 #include <console/ConsoleRegistry.h>
 
 constexpr size_t kMaxServerNameLength = 128u;
@@ -71,6 +72,7 @@ Console::Command<int64_t> SetDifficulty("SetDifficulty", "Set server difficulty 
 
     uDifficulty = (uint32_t)aDiff;
 
+    GameServer::Get()->UpdateSettings();
     spdlog::get("ConOut")->info("Difficulty has been set to {} - have all players reconnect to take effect", aDiff);
 });
 
@@ -750,6 +752,17 @@ void GameServer::HandleAuthenticationRequest(const ConnectionId_t aConnectionId,
         spdlog::info("New player {:x} '{}' has a bad password, kicking.", aConnectionId, remoteAddress);
         sendKick(RT::kWrongPassword);
     }
+}
+
+void GameServer::UpdateSettings()
+{
+    NotifySettingsChange notify{};
+    notify.Settings.Difficulty = uDifficulty.value_as<uint8_t>();
+    notify.Settings.GreetingsEnabled = bEnableGreetings;
+    notify.Settings.PvpEnabled = bEnablePvp;
+    notify.Settings.SyncPlayerHomes = bSyncPlayerHomes;
+
+    SendToPlayers(notify);
 }
 
 void GameServer::UpdateTitle() const

--- a/Code/server/GameServer.cpp
+++ b/Code/server/GameServer.cpp
@@ -57,6 +57,7 @@ Console::Command<> TogglePremium("TogglePremium", "Toggle Premium Tickrate on/of
 Console::Command<> TogglePvp("TogglePvp", "Toggle PvP on/off", [](Console::ArgStack&){
     bEnablePvp = !bEnablePvp;
     spdlog::get("ConOut")->info("PvP has been {}.", bEnablePvp == true ? "enabled" : "disabled");
+    GameServer::Get()->UpdateSettings();
 });
 
 Console::Command<int64_t> SetDifficulty("SetDifficulty", "Set server difficulty (0 being Novice and 5 being Legendary; default is 4)", [](Console::ArgStack& aStack) {

--- a/Code/server/GameServer.h
+++ b/Code/server/GameServer.h
@@ -46,6 +46,7 @@ struct GameServer final : Server
 
     void UpdateInfo();
     void UpdateTimeScale();
+    void UpdateSettings();
 
     // Packet dispatching
     void Send(ConnectionId_t aConnectionId, const ServerMessage& acServerMessage) const;


### PR DESCRIPTION
Add method UpdateSettings which will send a message to the client. Supports the same variables that are sent to the client upon connecting.

Using the TogglePvP command will now toggle PvP on the client when called.

Not sure if NotifySettingsChange and UpdateSettings are the best names, so feel free to change them if you have any ideas.

Merging this PR will add the commits to your existing PR on TiltedEvolution.